### PR TITLE
Reflect custom request options in Amazon Product API request

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,12 @@ var Promise = require('es6-promise').Promise;
 var runQuery = function fnRunQuery(credentials, method) {
   return function queryRun(query, cb) {
     var req = query.request || request;
+    var reqOptions = query.requestOptions || {};
+
+    // Remove request and requestOptions property
+    delete query.request;
+    delete query.requestOptions;
+
     var url = generateQueryString(query, method, credentials);
 
     var p = new Promise(function queryPromise(resolve, reject) {
@@ -25,7 +31,7 @@ var runQuery = function fnRunQuery(credentials, method) {
         }
       };
 
-      req(url, function performRequest(err, response, body) {
+      req(url, reqOptions, function performRequest(err, response, body) {
         if (err) {
           return failure(err);
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,12 +7,7 @@ var runQuery = function fnRunQuery(credentials, method) {
   return function queryRun(query, cb) {
     var req = query.request || request;
     var reqOptions = query.requestOptions || {};
-
-    // Remove request and requestOptions property
-    delete query.request;
-    delete query.requestOptions;
-
-    var url = generateQueryString(query, method, credentials);
+    var url;
 
     var p = new Promise(function queryPromise(resolve, reject) {
       var success = function fnSuccess(results) {
@@ -30,6 +25,12 @@ var runQuery = function fnRunQuery(credentials, method) {
           reject(err);
         }
       };
+
+      // Remove request and requestOptions property
+      query.request = undefined;
+      query.requestOptions = undefined;
+
+      url = generateQueryString(query, method, credentials);
 
       req(url, reqOptions, function performRequest(err, response, body) {
         if (err) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,7 @@ function formatQueryParams(query, method, credentials) {
 
   // format query keys
   for (param in query) { // eslint-disable-line no-restricted-syntax
-    if (Object.prototype.hasOwnProperty.call(query, param)) {
+    if (Object.prototype.hasOwnProperty.call(query, param) && query[param] !== undefined) {
       capitalized = capitalize(param);
       params[capitalized] = query[param];
     }


### PR DESCRIPTION
This PR allows to add custom request options to Amazon Product API by adding them in `requestOptions` query object property.

It also removes `request` and `requestOptions` property to avoid encoding them in the parameters of the URL we send to Amazon.